### PR TITLE
Get rid of including jquery.eye.css twice.

### DIFF
--- a/styles/all/template/event/overall_footer_after.html
+++ b/styles/all/template/event/overall_footer_after.html
@@ -53,6 +53,7 @@
 		//alert(MCP_TOPIC_MOVE);
 	</script>
 	{% INCLUDEJS '@alg_liveSearch/jquery.autocomplete.js' %}
+	{% INCLUDECSS '@alg_liveSearch/jquery.autocomplete.css' %}
 	{% INCLUDEJS '@alg_liveSearch/hoverIntent.minified.js' %}
 	{#  INCLUDEJS @alg_liveSearch/jquery.autocomplete.js > #}
 	{#  INCLUDEJS @alg_liveSearch/hoverIntent.minified.js --> #}
@@ -61,6 +62,7 @@
 		{%  INCLUDECSS '@alg_liveSearch/../jquery.eye/jquery.eye.css' %}
 	{% endif %}
 	{% INCLUDEJS '@alg_liveSearch/live_search.js' %}
+	{% INCLUDECSS '@alg_liveSearch/live_search.css' %}
 {% endif %}
 
  

--- a/styles/all/template/event/overall_header_head_append.html
+++ b/styles/all/template/event/overall_header_head_append.html
@@ -1,5 +1,0 @@
-{% if S_LIVE_SEARCH  %}
-	{% INCLUDECSS '@alg_liveSearch/jquery.autocomplete.css' %}
-	{% INCLUDECSS '@alg_liveSearch/live_search.css' %}
-	{% INCLUDECSS '@alg_liveSearch/../jquery.eye/jquery.eye.css' %}
-{% endif %}


### PR DESCRIPTION
Currently it's included twice: in overall_footer_after.html and in overall_header_head_append.html.
All inclusions can be put in 1 template event file.